### PR TITLE
Add installation manual for Nix users

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,63 @@ niriswitcher is now available in the AUR. You can use any of your AUR helpers to
 yay -S niriswitcher
 ```
 
+### Nix
+
+niriswitcher is also available on NUR. Nix users can setup NUR by following [this](https://nur.nix-community.org/documentation) guide, but a short summary is provided below.
+
+> [!NOTE]
+> NUR packages are built against Nixpkgs unstable.
+
+<details>
+
+<summary>
+
+#### With Flakes (without using Home Manager)
+
+</summary>
+
+For a simple flake based setup:
+
+- Add NUR to your flake inputs
+    ```nix
+    nur = {
+        url = "github:nix-community/NUR";
+        inputs.nixpkgs.follows = "nixpkgs";
+    };
+    ```
+- Add the NUR overlay to your NixOS configuration (optional)
+    ```nix
+    {
+        nixpkgs.overlays = [ nur.overlays.default ];
+    }
+    ```
+- To your packages list, add:
+    - `pkgs.nur.repos.Vortriz.niriswitcher` if you added the overlay
+    - `nur.legacyPackages."${pkgs.system}".repos.Vortriz.niriswitcher` if you did not use the overlay
+
+</details>
+
+<details>
+
+<summary>
+
+#### With Flakes (using Home Manager)
+
+</summary>
+
+- Add NUR to your flake inputs
+    ```nix
+    nur = {
+        url = "github:nix-community/NUR";
+        inputs.nixpkgs.follows = "nixpkgs";
+    };
+    ```
+- Add `nur.legacyPackages."${pkgs.system}".repos.Vortriz.homeManagerModules.niriswitcher` to your `imports` in `home.nix`
+- Set `programs.niriswitcher.enable = true`. Optionally, you can configure niriswitcher with `programs.niriswitcher.config` (for `config.toml`) and `programs.niriswitcher.style` (for `style.css`). The exact configuration values for these options are detailed in the section ahead.
+
+For more information on using the module itself, check out the [source file](https://github.com/Vortriz/nur-packages/blob/main/modules/home-manager/niriswitcher.nix).
+</details>
+
 ## Configuration
 
 First we need to execute the `niriswitcher` application. The program is
@@ -73,7 +130,7 @@ bind {
 ```
 
 > [!NOTE]
-> Remember to synchronize the keybinding set in Niri, with the one set for `niriswitcher`. For example, if you use `Mod+Tab` to trigger `niriswitcher` ensure that `modifier=Mod` in `config.ini` (see below).
+> Remember to synchronize the keybinding set in Niri, with the one set for `niriswitcher`. For example, if you use `Mod+Tab` to trigger `niriswitcher` ensure that `modifier=Mod` in `config.toml` (see below).
 
 ### Keybindings
 
@@ -88,7 +145,7 @@ By default, `niriswitcher` uses the following keybindings:
 
 - Release `Alt` to focus to currently selected application and close `niriswitcher`
 
-The default mappings and modifier key can be configured in the `config.ini` file.
+The default mappings and modifier key can be configured in the `config.toml` file.
 
 ### Options
 


### PR DESCRIPTION
I have packaged if for Nix and added it to NUR (Nix User Repository). So I added installation instructions for the same in here. Cheers!

PS - changed `config.ini` to `config.toml` at a couple of places. I hope this is correct.