### PR TITLE
Do not crash when apps don't have icons

### DIFF
--- a/src/niriswitcher/_widgets.py
+++ b/src/niriswitcher/_widgets.py
@@ -124,6 +124,7 @@ def new_app_icon_or_default(app_info: Gio.DesktopAppInfo, size):
     Returns:
         Gtk.Image: A Gtk.Image widget displaying the application's icon or a default icon.
     """
+    icon_name = ""
     if app_info:
         icon = app_info.get_icon()
         if isinstance(icon, Gio.ThemedIcon):


### PR DESCRIPTION
I have some apps without icons and the switcher crashes because `icon_name` is not defined and it tries to log it. This address that by defining it with an empty string at the start.